### PR TITLE
Adjust timepoint limits

### DIFF
--- a/R/prepare.R
+++ b/R/prepare.R
@@ -704,7 +704,8 @@ align_data_timepoints <- function(
   if (is.na(timepoint_limits[1])) {
     min_timepoint <- min(prepared_df$timepoint)
   } else {
-    min_timepoint <- timepoint_limits[1]
+    min_timepoint <- adjust_timepoint_limit(
+      timepoint_limits[1], min(prepared_df$timepoint), inputspec$timepoint_unit, direction = "earlier")
   }
   if (is.na(timepoint_limits[2])) {
     max_timepoint <- max(prepared_df$timepoint)
@@ -721,6 +722,7 @@ align_data_timepoints <- function(
 
   # TODO: Need to work out correct granularity to use based on df
   #  as don't want to insert unnecessary rows
+  # if the supplied limit(s) don't match the df granularity, be kind and adjust it
   all_timepoints <- seq(
     min_timepoint,
     max_timepoint,
@@ -761,6 +763,24 @@ align_data_timepoints <- function(
   df_out
 }
 
+# -----------------------------------------------------------------------------
+#' Adjust the supplied timepoint_limit to align with data if necessary
+#'
+#' @param timepoint_limit datetime value supplied by user
+#' @param timepoint_value datetime value in the data
+#' @param timepoint_unit granularity specified by user
+#' @param direction direction of desired adjustment. Either "earlier" or "later"
+#'
+#' @returns Datetime
+#' @noRd
+adjust_timepoint_limit <- function(
+    timepoint_limit,
+    timepoint_value,
+    timepoint_unit,
+    direction
+) {
+
+}
 
 # -----------------------------------------------------------------------------
 #' Wrapper for max function

--- a/R/prepare.R
+++ b/R/prepare.R
@@ -784,8 +784,26 @@ adjust_timepoint_limit <- function(
   timepoint_unit,
   limit_type
 ) {
+
+  # if everything is in days then no changes needed
+  if (
+    timepoint_unit == "day" &&
+      inherits(timepoint_limit, what = "Date") && inherits(timepoint_values, what = "Date")
+  ) {
+    return(timepoint_limit)
+  }
+
+  # ensure limit is of same class as values
+  if (inherits(timepoint_values, what = "POSIXct")) {
+    timepoint_limit <- as.POSIXct(timepoint_limit)
+  } else if (inherits(timepoint_values, what = "POSIXlt")) {
+    timepoint_limit <- as.POSIXlt(timepoint_limit)
+  } else if (inherits(timepoint_values, what = "Date")) {
+    timepoint_limit <- as.Date(timepoint_limit)
+  }
+
   # Estimate number of units needed
-  if(timepoint_unit %in% c("month", "quarter", "year")){
+  if (timepoint_unit %in% c("month", "quarter", "year")) {
     unit <- "day"
     unit_length <- switch(
       timepoint_unit,
@@ -793,7 +811,7 @@ adjust_timepoint_limit <- function(
       quarter = 90,
       year = 365
     )
-  } else{
+  } else {
     unit <- timepoint_unit
     unit_length <- 1
   }
@@ -810,7 +828,7 @@ adjust_timepoint_limit <- function(
 
   # Generate candidate dates
   candidate_dates <- seq(
-    from = min(timepoint_values),
+    from = base_date,
     by = paste0(ifelse(timepoint_limit < base_date, "-", ""), "1 ", timepoint_unit),
     length.out = estimated_units_needed
   )

--- a/R/prepare.R
+++ b/R/prepare.R
@@ -699,17 +699,16 @@ align_data_timepoints <- function(
   # initialise column names to avoid R CMD check Notes
   timepoint <- value <- NULL
 
-  # TODO: Need to work out correct limits to use based on df
-  #  in case supplied limits don't match df granularity
-  if (is.na(timepoint_limits[1])) {
-    min_timepoint <- min(prepared_df$timepoint)
-  } else {
+  min_timepoint <- min(prepared_df$timepoint)
+  max_timepoint <- max(prepared_df$timepoint)
+  if (!is.na(timepoint_limits[1])) {
     min_timepoint <- adjust_timepoint_limit(
-      timepoint_limits[1], min(prepared_df$timepoint), inputspec$timepoint_unit, direction = "earlier")
+      timepoint_limits[1],
+      min(prepared_df$timepoint),
+      inputspec$timepoint_unit,
+      direction = "earlier")
   }
-  if (is.na(timepoint_limits[2])) {
-    max_timepoint <- max(prepared_df$timepoint)
-  } else {
+  if (!is.na(timepoint_limits[2])) {
     # NOTE: While timepoint_limits should already be a date class,
     # if user supplies an NA first in the vector, the second value gets coerced
     # to numeric and leads to an error in seq() later on
@@ -779,6 +778,9 @@ adjust_timepoint_limit <- function(
     timepoint_unit,
     direction
 ) {
+
+  diff <- timepoint_value - timepoint_limit
+seq(timepoint_value, timepoint_limit, by = timepoint_unit)
 
 }
 

--- a/tests/testthat/test-prepare.R
+++ b/tests/testthat/test-prepare.R
@@ -1250,24 +1250,297 @@ test_that("arrange_items() sorts by two item_orders", {
 })
 
 
-test_that("adjust_timepoint_limit() moves supplied limit appropriately", {
+test_that("adjust_timepoint_limit() moves supplied limit appropriately for months", {
+  # min_timepoint before first timepoint
   expect_equal(
     adjust_timepoint_limit(
       timepoint_limit = as.Date("2022-01-01"),
-      timepoint_value = as.Date("2022-01-20"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "month", length.out = 5),
       timepoint_unit = "month",
-      direction = "earlier"
+      limit_type = "min"
+    ),
+    as.Date("2022-01-20")
+  )
+
+  # min_timepoint at first timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-20"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "month", length.out = 5),
+      timepoint_unit = "month",
+      limit_type = "min"
+    ),
+    as.Date("2022-01-20")
+  )
+
+  # min_timepoint between timepoint_values with gaps
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-05-01"),
+      timepoint_values = c(as.Date("2022-01-20"), as.Date("2023-01-20")),
+      timepoint_unit = "month",
+      limit_type = "min"
+    ),
+    as.Date("2022-05-20")
+  )
+
+  # min_timepoint after last timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2023-01-01"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "month", length.out = 5),
+      timepoint_unit = "month",
+      limit_type = "min"
+    ),
+    as.Date("2023-01-20")
+  )
+
+  # max_timepoint after last timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2023-01-01"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "month", length.out = 5),
+      timepoint_unit = "month",
+      limit_type = "max"
+    ),
+    as.Date("2022-12-20")
+  )
+
+  # max_timepoint between timepoint_values with gaps
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-05-01"),
+      timepoint_values = c(as.Date("2022-01-20"), as.Date("2023-01-20")),
+      timepoint_unit = "month",
+      limit_type = "max"
+    ),
+    as.Date("2022-04-20")
+  )
+
+  # max_timepoint before first timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-01"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "month", length.out = 5),
+      timepoint_unit = "month",
+      limit_type = "max"
     ),
     as.Date("2021-12-20")
   )
+
+})
+
+test_that("adjust_timepoint_limit() moves supplied limit appropriately for weeks", {
+  # min_timepoint before first timepoint
   expect_equal(
     adjust_timepoint_limit(
       timepoint_limit = as.Date("2022-01-01"),
-      timepoint_value = as.Date("2022-01-20"),
-      timepoint_unit = "month",
-      direction = "later"
+      timepoint_values = seq(as.Date("2022-01-20"), by = "week", length.out = 5),
+      timepoint_unit = "week",
+      limit_type = "min"
     ),
-    as.Date("2022-02-20")
+    as.Date("2022-01-06")
+  )
+
+  # min_timepoint between timepoint_values with gaps
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-02-01"),
+      timepoint_values = c(as.Date("2022-01-20"), as.Date("2022-02-17")),
+      timepoint_unit = "week",
+      limit_type = "min"
+    ),
+    as.Date("2022-02-03")
+  )
+
+  # min_timepoint after last timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-02-20"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "week", length.out = 5),
+      timepoint_unit = "week",
+      limit_type = "min"
+    ),
+    as.Date("2022-02-24")
+  )
+
+  # max_timepoint after last timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-02-20"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "week", length.out = 5),
+      timepoint_unit = "week",
+      limit_type = "max"
+    ),
+    as.Date("2022-02-17")
+  )
+
+  # max_timepoint between timepoint_values with gaps
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-02-01"),
+      timepoint_values = c(as.Date("2022-01-20"), as.Date("2022-02-17")),
+      timepoint_unit = "week",
+      limit_type = "max"
+    ),
+    as.Date("2022-01-27")
+  )
+
+  # max_timepoint before first timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-01"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "week", length.out = 5),
+      timepoint_unit = "week",
+      limit_type = "max"
+    ),
+    as.Date("2021-12-30")
+  )
+
+})
+
+
+test_that("adjust_timepoint_limit() moves supplied limit appropriately for years", {
+  # min_timepoint before first timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-01"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "year", length.out = 5),
+      timepoint_unit = "year",
+      limit_type = "min"
+    ),
+    as.Date("2022-01-20")
+  )
+
+  # min_timepoint at first timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-20"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "year", length.out = 5),
+      timepoint_unit = "year",
+      limit_type = "min"
+    ),
+    as.Date("2022-01-20")
+  )
+
+  # min_timepoint between timepoint_values with gaps
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-05-01"),
+      timepoint_values = c(as.Date("2022-01-20"), as.Date("2027-01-20")),
+      timepoint_unit = "year",
+      limit_type = "min"
+    ),
+    as.Date("2023-01-20")
+  )
+
+  # min_timepoint after last timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2029-01-01"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "year", length.out = 5),
+      timepoint_unit = "year",
+      limit_type = "min"
+    ),
+    as.Date("2029-01-20")
+  )
+
+  # max_timepoint after last timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2029-01-01"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "year", length.out = 5),
+      timepoint_unit = "year",
+      limit_type = "max"
+    ),
+    as.Date("2028-01-20")
+  )
+
+  # max_timepoint between timepoint_values with gaps
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2023-05-01"),
+      timepoint_values = c(as.Date("2022-01-20"), as.Date("2027-01-20")),
+      timepoint_unit = "year",
+      limit_type = "max"
+    ),
+    as.Date("2023-01-20")
+  )
+
+  # max_timepoint before first timepoint
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-01"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "year", length.out = 5),
+      timepoint_unit = "year",
+      limit_type = "max"
+    ),
+    as.Date("2021-01-20")
+  )
+
+})
+
+test_that("adjust_timepoint_limit() moves supplied limit appropriately for hours", {
+  # NOTE: coerce posixct values to numeric to ignore timezones
+
+  # min_timepoint before first timepoint
+  expect_equal(
+    as.numeric(adjust_timepoint_limit(
+      timepoint_limit = as.POSIXct("2022-01-02 08:30:00"),
+      timepoint_values = seq(
+        as.POSIXct("2022-01-02 12:00:00"),
+        as.POSIXct("2022-01-03 12:00:00"),
+        by = "hour"
+      ),
+      timepoint_unit = "hour",
+      limit_type = "min"
+    )),
+    as.numeric(as.POSIXct("2022-01-02 09:00:00"))
+  )
+
+  # min_timepoint at first timepoint
+  expect_equal(
+    as.numeric(adjust_timepoint_limit(
+      timepoint_limit = as.POSIXct("2022-01-02 12:00:00"),
+      timepoint_values = seq(
+        as.POSIXct("2022-01-02 12:00:00"),
+        as.POSIXct("2022-01-03 12:00:00"),
+        by = "hour"
+      ),
+      timepoint_unit = "hour",
+      limit_type = "min"
+    )),
+    as.numeric(as.POSIXct("2022-01-02 12:00:00"))
+  )
+
+  # min_timepoint between timepoint_values
+  expect_equal(
+    as.numeric(adjust_timepoint_limit(
+      timepoint_limit = as.POSIXct("2022-01-02 15:30:00"),
+      timepoint_values = seq(
+        as.POSIXct("2022-01-02 12:00:00"),
+        as.POSIXct("2022-01-03 12:00:00"),
+        by = "hour"
+      ),
+      timepoint_unit = "hour",
+      limit_type = "min"
+    )),
+    as.numeric(as.POSIXct("2022-01-02 16:00:00"))
+  )
+
+  # max_timepoint after last timepoint
+  expect_equal(
+    as.numeric(adjust_timepoint_limit(
+      timepoint_limit = as.POSIXct("2022-01-03 15:30:00"),
+      timepoint_values = seq(
+        as.POSIXct("2022-01-02 12:00:00"),
+        as.POSIXct("2022-01-03 12:00:00"),
+        by = "hour"
+      ),
+      timepoint_unit = "hour",
+      limit_type = "max"
+    )),
+    as.numeric(as.POSIXct("2022-01-03 15:00:00"))
   )
 
 })

--- a/tests/testthat/test-prepare.R
+++ b/tests/testthat/test-prepare.R
@@ -1399,7 +1399,6 @@ test_that("adjust_timepoint_limit() moves supplied limit appropriately for weeks
 
 })
 
-
 test_that("adjust_timepoint_limit() moves supplied limit appropriately for years", {
   # min_timepoint before first timepoint
   expect_equal(
@@ -1476,6 +1475,67 @@ test_that("adjust_timepoint_limit() moves supplied limit appropriately for years
       limit_type = "max"
     ),
     as.Date("2021-01-20")
+  )
+
+})
+
+test_that("adjust_timepoint_limit() moves supplied limit appropriately for days", {
+  # NOTE: coerce posixct values to numeric to ignore timezones
+
+  # if everything is a Date then nothing changes
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-01"),
+      timepoint_values = seq(as.Date("2022-01-20"), by = "quarter", length.out = 5),
+      timepoint_unit = "day",
+      limit_type = "max"
+    ),
+    as.Date("2022-01-01")
+  )
+
+  # limit and values are posixct
+  expect_equal(
+    as.numeric(adjust_timepoint_limit(
+      timepoint_limit = as.POSIXct("2022-01-02 08:30:00"),
+      timepoint_values = seq(
+        as.POSIXct("2022-01-02 12:00:00"),
+        by = "day",
+        length.out = 5
+      ),
+      timepoint_unit = "day",
+      limit_type = "min"
+    )),
+    as.numeric(as.POSIXct("2022-01-02 12:00:00"))
+  )
+
+  # limit is date, values are posixct
+  expect_equal(
+    as.numeric(adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-03"),
+      timepoint_values = seq(
+        as.POSIXct("2022-01-02 12:00:00"),
+        by = "day",
+        length.out = 5
+      ),
+      timepoint_unit = "day",
+      limit_type = "min"
+    )),
+    as.numeric(as.POSIXct("2022-01-03 12:00:00"))
+  )
+
+  # limit is posixct, values are date
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.POSIXct("2022-01-04 12:00:00"),
+      timepoint_values = seq(
+        as.Date("2022-01-02"),
+        by = "day",
+        length.out = 5
+      ),
+      timepoint_unit = "day",
+      limit_type = "max"
+    ),
+    as.Date("2022-01-04")
   )
 
 })

--- a/tests/testthat/test-prepare.R
+++ b/tests/testthat/test-prepare.R
@@ -1248,3 +1248,27 @@ test_that("arrange_items() sorts by two item_orders", {
     )
   )
 })
+
+
+test_that("adjust_timepoint_limit() moves supplied limit appropriately", {
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-01"),
+      timepoint_value = as.Date("2022-01-20"),
+      timepoint_unit = "month",
+      direction = "earlier"
+    ),
+    as.Date("2021-12-20")
+  )
+  expect_equal(
+    adjust_timepoint_limit(
+      timepoint_limit = as.Date("2022-01-01"),
+      timepoint_value = as.Date("2022-01-20"),
+      timepoint_unit = "month",
+      direction = "later"
+    ),
+    as.Date("2022-02-20")
+  )
+
+})
+


### PR DESCRIPTION
if user supplies a timepoint_limit value that doesn't match the granularity of the data, find the next value that does match the granularity.